### PR TITLE
refactor: import native modules from `node:`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,29 @@
   ],
   "rules": {
     "prettier/prettier": "error",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "Buffer",
+        "message": "Import Buffer from `node:buffer` instead"
+      },
+      {
+        "name": "process",
+        "message": "Import process from `node:process` instead"
+      },
+      {
+        "name": "setTimeout",
+        "message": "Import setTimeout from `node:timers` instead"
+      },
+      {
+        "name": "setInterval",
+        "message": "Import setInterval from `node:timers` instead"
+      },
+      {
+        "name": "setImmediate",
+        "message": "Import setImmediate from `node:timers` instead"
+      }
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@discordjs/collection": "^0.5.0",
         "axios": "^0.25.0",
-        "events": "^3.3.0",
         "eventsource": "^1.1.0"
       },
       "devDependencies": {
@@ -854,14 +853,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/eventsource": {
@@ -2367,11 +2358,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@discordjs/collection": "^0.5.0",
     "axios": "^0.25.0",
-    "events": "^3.3.0",
     "eventsource": "^1.1.0"
   },
   "devDependencies": {

--- a/src/bridge/Bridge.ts
+++ b/src/bridge/Bridge.ts
@@ -1,4 +1,5 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
+import { setImmediate } from 'node:timers';
 import { LightManager } from '../managers/LightManager';
 import { Events } from '../util/Events';
 import { ActionManager } from './actions/ActionManager';

--- a/src/bridge/rest/RouteRateLimit.ts
+++ b/src/bridge/rest/RouteRateLimit.ts
@@ -1,4 +1,5 @@
 import { Routes } from '../../util/Routes';
+import { setTimeout } from 'node:timers';
 
 export interface RouteHandlerOptions {
 	interval: number;


### PR DESCRIPTION
It's not good to use global variables, so I imported all the native modules from the `node:` protocol. I also added eslint rules and uninstalled the useless `events` package.